### PR TITLE
Rename field site id 

### DIFF
--- a/R/build_targets.R
+++ b/R/build_targets.R
@@ -19,18 +19,18 @@
 #'@export
 #'
 build_targets <- function(table_schema,
-                            table_description,
-                            start_date,
-                            end_date,
-                            id_value,
-                            description_string,
-                            about_string,
-                            about_title,
-                            theme_title,
-                            destination_path,
-                            link_items,
-                            thumbnail_link,
-                            thumbnail_title
+                          table_description,
+                          start_date,
+                          end_date,
+                          id_value,
+                          description_string,
+                          about_string,
+                          about_title,
+                          theme_title,
+                          destination_path,
+                          link_items,
+                          thumbnail_link,
+                          thumbnail_title
 ){
 
   # insitu_targets_link <- config$insitu_targets_file

--- a/R/get_site_coords.R
+++ b/R/get_site_coords.R
@@ -10,9 +10,15 @@ get_site_coords <- function(site_metadata, sites){
 
   site_df <- readr::read_csv(site_metadata, col_types = cols())
 
-  relevant_sites <- sites[which(sites %in% site_df$field_site_id)]
+  if ('site_id' %in% names(site_df) == FALSE){
+    site_df <- site_df |>
+      rename(site_id = field_site_id) ## rename the neon site_id column
+  }
 
-  site_lat_lon <- lapply(relevant_sites, function(i) c(site_df$longitude[which(site_df[,2] == i)], site_df$latitude[which(site_df[,2] == i)]))
+  relevant_sites <- sites[which(sites %in% site_df$site_id)]
+
+  site_lat_lon <- lapply(relevant_sites, function(i){c(site_df$longitude[which(site_df$site_id == i)],
+                                                       site_df$latitude[which(site_df$site_id == i)])})
 
   return(site_lat_lon)
 }


### PR DESCRIPTION
I'm running into errors using stac4cast on the [usgsrc4cast CI ](https://github.com/eco4cast/usgsrc4cast-ci)because our metadata has sites named as `site_id` but some of the stac4cast functions assume the NEON column name `field_site_id`. This PR adds in a renaming similar to the bbox function to rename field_site_id to site_id if that is the case. Also make the get_coords function more explicit about column names because not all site metadata will have the same column position for the `site_id` column 